### PR TITLE
Throw a meaningful Error on timeout. Fixes #1

### DIFF
--- a/src/Adapter/Node.js
+++ b/src/Adapter/Node.js
@@ -60,7 +60,13 @@ class Node {
 
             if (postBody) req.write(postBody);
 
-            req.on('error', reject);
+            req.on('error', (err) => {
+                if (req.aborted) {
+                    err = new Error(`Request timed out after ${this.timeout} milliseconds`);
+                    err.code = 'ETIMEDOUT';
+                }
+                reject(err);
+            });
             req.end();
         });
     }

--- a/test/flora-client-node.spec.js
+++ b/test/flora-client-node.spec.js
@@ -551,7 +551,7 @@ describe('Flora node client', () => {
                 .catch(err => {
                     expect(err)
                         .to.be.instanceOf(Error)
-                        .and.to.have.property('code', 'ECONNRESET');
+                        .and.to.have.property('code', 'ETIMEDOUT');
                     done();
                 });
         });
@@ -567,7 +567,7 @@ describe('Flora node client', () => {
                 .then(() => done(new Error('Expected promise to reject')))
                 .catch(err => {
                     expect(err).to.be.instanceOf(Error)
-                        .and.to.have.property('code', 'ECONNRESET');
+                        .and.to.have.property('code', 'ETIMEDOUT');
                     done();
                 });
         });


### PR DESCRIPTION
Match the behaviour of the browser version and throw a nice error message when a request times out instead of the default ECONNRESET ("socket hung up").

Although this actually changes the error code, I consider this as a bug fix and thus no breaking change (major version).