### PR TITLE
Improve error handling on unexpected content-type

### DIFF
--- a/src/Adapter/Node.js
+++ b/src/Adapter/Node.js
@@ -39,7 +39,8 @@ class Node {
                     let response;
 
                     if (!contentType.startsWith('application/json')) {
-                        return reject(new Error(`Received response with invalid content type: "${contentType}"`));
+                        if (res.statusCode < 400) return reject(new Error(`Server Error: Invalid content type: "${contentType}")`));
+                        return reject(new Error(`Server Error: ${res.statusMessage || `Invalid content type: "${contentType}"`}`));
                     }
 
                     try {
@@ -50,7 +51,7 @@ class Node {
 
                     if (res.statusCode < 400) return resolve(response);
 
-                    const msg = response.error && response.error.message ? response.error.message : 'error';
+                    const msg = response.error && response.error.message ? response.error.message : `Server Error: ${res.statusMessage || 'Invalid JSON'}`;
                     const err = new Error(msg);
                     err.response = response;
                     return reject(err);

--- a/src/Adapter/Xhr.js
+++ b/src/Adapter/Xhr.js
@@ -41,7 +41,8 @@ class Xhr {
                 let response;
 
                 if (contentType.indexOf('application/json') !== 0) {
-                    return reject(new Error(`Received response with invalid content type: "${contentType}"`));
+                    if (xhr.status < 400) return reject(new Error(`Server Error: Invalid content type: "${contentType}")`));
+                    return reject(new Error(`Server Error: ${xhr.statusText || `Invalid content type: "${contentType}"`}`));
                 }
 
                 try {
@@ -52,7 +53,7 @@ class Xhr {
 
                 if (xhr.status < 400) return resolve(response);
 
-                const msg = response.error && response.error.message ? response.error.message : 'error';
+                const msg = response.error && response.error.message ? response.error.message : `Server Error: ${xhr.statusText || 'Invalid JSON'}`;
                 const err = new Error(msg);
                 err.response = response;
                 return reject(err);

--- a/test/flora-client-browser.spec.js
+++ b/test/flora-client-browser.spec.js
@@ -355,7 +355,7 @@ describe('Flora client', () => {
                 .then(() => done(new Error('Expected promise to reject')))
                 .catch(err => {
                     expect(err).to.be.instanceOf(Error)
-                        .with.property('message', 'Received response with invalid content type: "text/html"');
+                        .with.property('message', 'Server Error: Internal Server Error');
                     done();
                 });
 

--- a/test/flora-client-node.spec.js
+++ b/test/flora-client-node.spec.js
@@ -432,7 +432,7 @@ describe('Flora node client', () => {
                 .then(() => done(new Error('Expected promise to reject')))
                 .catch(err => {
                     expect(err).to.be.instanceOf(Error)
-                        .with.property('message', 'Received response with invalid content type: "text/html"');
+                        .with.property('message', 'Server Error: Invalid content type: "text/html"');
                     done();
                 });
         });


### PR DESCRIPTION
Instead of `Received response with invalid content type: "..."`, reject with the `statusMessage` received by the server (such as "Forbidden"), or fall back to `Invalid content type: "..."`.

This improves the readability of common errors like "Temporarily Unavailable" (503), when the server will not send JSON anymore.