### PR TITLE
Fix tests for JSON error message

### DIFF
--- a/test/flora-client-browser.spec.js
+++ b/test/flora-client-browser.spec.js
@@ -342,7 +342,6 @@ describe('Flora client', () => {
                 .then(() => done(new Error('Expected promise to reject')))
                 .catch((err) => {
                     expect(err).to.be.instanceof(SyntaxError)
-                        .with.property('message', 'Unexpected token : in JSON at position 7');
                     done();
                 });
 

--- a/test/flora-client-node.spec.js
+++ b/test/flora-client-node.spec.js
@@ -416,8 +416,7 @@ describe('Flora node client', () => {
             api.execute({ resource: 'user' })
                 .then(() => done(new Error('Expected promise to reject')))
                 .catch((err) => {
-                    expect(err).to.be.instanceOf(SyntaxError)
-                        .with.property('message', 'Unexpected token : in JSON at position 7');
+                    expect(err).to.be.instanceOf(SyntaxError);
                     done();
                 });
         });


### PR DESCRIPTION
In Node.js v20, tests fail because JSON.parse error messages seem to have changed:

```diff
- Unexpected token : in JSON at position 7
+ Uncaught SyntaxError: Expected ',' or ']' after array element in JSON at position 7
```

Thus, the "should reject promise if JSON cannot be parsed" test fails because the `SyntaxError` is emitted correctly, but with a different message.
I'd suggest to remove the message comparison altogether.